### PR TITLE
Add socket observation capability and tests for it

### DIFF
--- a/cold-brew-test.js
+++ b/cold-brew-test.js
@@ -16,7 +16,9 @@ function createClient() {
     .withCapabilities({
       browserName: 'chrome',
       chromeOptions: {
-        args: ['--use-fake-ui-for-media-stream']
+        args: [
+          '--use-fake-ui-for-media-stream',
+        ]
       }
     })
     .build()
@@ -47,7 +49,7 @@ function addColdBrewMethods(client) {
    * repeatedly if it is used within a webdriver.wait() call,
    * e.g. client.wait(client.untilRTCEvents('signalingstatechange', 'iceconnectionstatechange'))
    */
-  client.untilRTCEvents = function(...events) {
+  client.untilRTCEvents = function(events) {
     return function() {
       return client.executeScript(function(evts) {
         return evts.every(windowHasEvent);
@@ -76,8 +78,8 @@ function addColdBrewMethods(client) {
    * @param   events description
    * @return {type}           description
    */
-  client.waitUntilRTCEvents = function(...events) {
-    return client.wait(client.untilRTCEvents(...events));
+  client.waitUntilRTCEvents = function(events) {
+    return client.wait(client.untilRTCEvents(events));
   }
 
 

--- a/cold-brew-test.js
+++ b/cold-brew-test.js
@@ -119,6 +119,21 @@ function addColdBrewMethods(client) {
     return client.wait(client.untilRTCEvents(events, options), timeout);
   }
 
+  
+  client.untilSendSignaling = function(events) {
+    return client.executeScript(function (events) {
+      // Check to make sure coldBrewData has been initialized
+      if (!(window.coldBrewData && window.coldBrewData.RTCEvents)) {
+        return false;
+      }
+      
+      const outgoingSocketEvents = window.coldBrewData.socketEvents.outgoing
+        .map(event => event.type);
+      
+      return events.every(eventName => outgoingSocketEvents.includes(eventName))
+    }, events)
+  }
+
 
   /**
    * findElementByAttributes - allows the webdriver to locate elements

--- a/cold-brew-test.js
+++ b/cold-brew-test.js
@@ -49,24 +49,27 @@ function addColdBrewMethods(client) {
    * repeatedly if it is used within a webdriver.wait() call,
    * e.g. client.wait(client.untilRTCEvents('signalingstatechange', 'iceconnectionstatechange'))
    */
-  client.untilRTCEvents = function(events) {
+  client.untilRTCEvents = function (events, options = {}) {
+    const { inOrder } = options;
+    if (inOrder && typeof inOrder !== 'boolean') {
+      throw new TypeError(
+        `Invalid option passed into untilRTCEvents: inOrder: ${inOrder}`
+      );
+    }
+
     return function() {
-      return client.executeScript(function(evts) {
-        return evts.every(windowHasEvent);
-
-        function windowHasEvent(eventName) {
-          if (!window.RTCEvents) return false;
-
-          for (let i = 0; i < window.RTCEvents.length; i++) {
-            console.log('checking event', eventName);
-            if(window.RTCEvents[i].type === eventName) {
-              return true;
-            }
-          }
-
-          return false;
+      return client.executeScript(function (events, inOrder) {
+        if (!inOrder) {
+          return events.every((eventType) => {
+            return window.coldBrewData.RTCEvents
+              .map(event => event.type)
+              .includes(eventType)
+          });
         }
-      }, events);
+
+       // Need to implement functionality for inOrder === true;
+          
+      }, events, inOrder);
     }
   };
 

--- a/example/chat/main.js
+++ b/example/chat/main.js
@@ -36,7 +36,7 @@ $(document).ready(() => {
   let sendVideo = $('#sendVideo');
   sendVideo.attr('disabled', true);
 
-  socket = io();
+  socket = observeSignaling(io());
   $('form').on('submit', (e) => {
     e.preventDefault();
   });

--- a/example/chat/server.js
+++ b/example/chat/server.js
@@ -43,3 +43,9 @@ app.get('/', (req, res) => {
 server.listen(3000, () => {
   console.log('listnin on 3k');
 });
+
+module.exports = {
+  resetNumClients: function (num) {
+    numClients = num;
+  },
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cold-brew",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "A testing module for TDD with apps that use the RTCPeerConnection API",
   "main": "cold-brew-test.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cold-brew",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "A testing module for TDD with apps that use the RTCPeerConnection API",
   "main": "cold-brew-test.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cold-brew",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "A testing module for TDD with apps that use the RTCPeerConnection API",
   "main": "cold-brew-test.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -287,13 +287,13 @@ function, the following function are added to it:
   * [client.do(navigationEvents)](#client-do)
 
 <a name="client-until-rtc-events"></a>
-**client.untilRTCEvents(...events)**
+**client.untilRTCEvents(events)**
 
 Returns a promise that will resolve with a truthy value when the specified
 events have fired on the RTCPeerConnection object.
 
 Parameters:
-* *...events*: Any number of names of events that fire on the RTCPeerConnection
+* *events*: An array of names of events that fire on the RTCPeerConnection
   object in the browser
 
 Returns: A promise that will resolve with a truthy value when the specified
@@ -312,14 +312,14 @@ describe('RTCPeerConnection', function() {
     client1.get('https://www.example.com');
     client2.get('https://www.example.com');
 
-    client1.wait(client1.untilRTCEvents('signalingstatechange', 'datachannel'))
+    client1.wait(client1.untilRTCEvents(['signalingstatechange', 'datachannel']))
       .then((occurred) => {if (occurred) done()});
   });
 });
 ```
 
 <a name="client-wait-until-rtc-events"></a>
-**client.waitUntilRTCEvents(...events)**
+**client.waitUntilRTCEvents(events)**
 
 Convenience method, equivalent to invoking `client.wait(client.untilRTCEvents(...events))`
 
@@ -334,7 +334,7 @@ describe('RTCPeerConnection', function() {
     client1.get('https://www.example.com');
     client2.get('https://www.example.com');
 
-    client1.waituntilRTCEvents('signalingstatechange', 'datachannel')
+    client1.waituntilRTCEvents(['signalingstatechange', 'datachannel'])
       .then((occurred) => {if (occurred) done()});
   });
 });

--- a/readme.md
+++ b/readme.md
@@ -321,7 +321,7 @@ describe('RTCPeerConnection', function() {
 <a name="client-wait-until-rtc-events"></a>
 **client.waitUntilRTCEvents(events)**
 
-Convenience method, equivalent to invoking `client.wait(client.untilRTCEvents(...events))`
+Convenience method, equivalent to invoking `client.wait(client.untilRTCEvents(events))`
 
 Usage example:
 ```javascript

--- a/rtc.js
+++ b/rtc.js
@@ -63,4 +63,7 @@ function coldBrewRTC(servers, options, coldBrewConfig) {
 
 class ColdBrewError extends Error {};
 
-module.exports = { coldBrewRTC, RTC_PEER_CONNECTION_EVENTS };
+if (typeof module !== 'undefined') {
+  module.exports = { coldBrewRTC, RTC_PEER_CONNECTION_EVENTS };
+}
+

--- a/rtc.js
+++ b/rtc.js
@@ -1,9 +1,14 @@
-if (window.RTCEvents) throw new ColdBrewError(
-  'Cannot capture RTC events, window.RTCEvents property already exists');
+if (window.coldBrewData) throw new ColdBrewError(
+  'Cannot capture RTC events, window.coldBrewData property already exists');
 
-// Attach an RTCEvents array to the window object to keep a record of the
+// Attach a coldBrewData object to the window object to keep a record of the
 // events that fire on the RTCPeerConnection object
-window.RTCEvents = [];
+window.coldBrewData = {
+  RTCEvents: [],
+  socketEvents: [],
+  peerConnections: {},
+  sockets: {},
+};
 
 // An array of all of the events that fire on the RTCPeerConnection object
 const RTC_PEER_CONNECTION_EVENTS = [
@@ -52,7 +57,7 @@ function coldBrewRTC(servers, options, coldBrewConfig) {
   if (!production) {
     listeners.forEach((listener) => {
       peerConnection.addEventListener(listener, (event) => {
-        window.RTCEvents.push(event);
+        window.coldBrewData.RTCEvents.push(event);
       });
     });
   }

--- a/test/cold-brew.spec.js
+++ b/test/cold-brew.spec.js
@@ -158,7 +158,7 @@ describe('coldBrew', function () {
       client1.waitUntilRTCEvents([
         'thiseventshouldnotexist',
         'orthisone',
-      ], {}, 6000)
+      ], {}, 3000)
         .then((occurred) => {
           if (occurred) {
             done(new Error('waitUntilRTCEvents reported that a non-existent event occurred'))
@@ -173,7 +173,7 @@ describe('coldBrew', function () {
     });
   });
 
-  describe('waitUntilSignalingEvents', function () {
+  describe('waitUntilSendSignaling', function () {
     beforeEach(function () {
       client1 = coldBrew.createClient();
       client2 = coldBrew.createClient();
@@ -188,6 +188,25 @@ describe('coldBrew', function () {
       client1.waitUntilSendSignaling([
         'join'
       ]).then((occurred) => { if (occurred) done() });
+    });
+
+    it('should not be able to detect events that have not happened', function (done) {
+      this.timeout(10000);
+
+      client1.get(ADDRESS);
+      client2.get(ADDRESS);
+
+      client1.waitUntilSendSignaling([
+        'thiseventshouldnotexist'
+      ], 3000)
+        .then((occurred) => {
+          if (occurred) {
+            done(new Error('waitUntilSendSignaling detected nonexistant event'))
+          }
+        })
+        .catch((err) => {
+          if (err) done()
+        });
     });
 
     afterEach(function (done) {

--- a/test/cold-brew.spec.js
+++ b/test/cold-brew.spec.js
@@ -55,6 +55,7 @@ describe('coldBrew', function () {
     let client;
 
     before(function () {
+      this.timeout(5000);
       client = coldBrew.createClient();
     });
 
@@ -131,9 +132,11 @@ describe('coldBrew', function () {
       client1.get(ADDRESS);
       client2.get(ADDRESS);
 
-      client1.waitUntilRTCEvents(
-        'signalingstatechange'
-      ).then((occurred) => {if (occurred) done()});
+      client1.waitUntilRTCEvents([
+        'signalingstatechange',
+        'addstream',
+        'datachannel'
+      ]).then((occurred) => { if (occurred) done() });
     });
 
     after(function (done) {

--- a/test/cold-brew.spec.js
+++ b/test/cold-brew.spec.js
@@ -9,17 +9,6 @@ const { resetNumClients } = require('./../example/chat/server.js');
 let ADDRESS = 'http://localhost:3000';
 
 describe('coldBrew', function () {
-  // before(function (done) {
-  //   this.timeout(10000);
-
-  //   ngrok.connect(3000, function (err, url) {
-  //     if (err) throw err;
-
-  //     ADDRESS = url;
-  //     done();
-  //   });
-  // });
-
   beforeEach(function () {
     resetNumClients(0);
   });
@@ -176,13 +165,34 @@ describe('coldBrew', function () {
           }
         })
         .catch((err) => { if (err) done() });
-      
-    })
+    });
 
     afterEach(function (done) {
       client1.quit();
       client2.quit().then(() => done());
     });
+  });
 
+  describe('waitUntilSignalingEvents', function () {
+    beforeEach(function () {
+      client1 = coldBrew.createClient();
+      client2 = coldBrew.createClient();
+    })
+
+    it('should be able to detect that signaling events have occurred', function (done) {
+      this.timeout(10000);
+
+      client1.get(ADDRESS);
+      client2.get(ADDRESS);
+
+      client1.waitUntilSendSignaling([
+        'join'
+      ]).then((occurred) => { if (occurred) done() });
+    });
+
+    afterEach(function (done) {
+      client1.quit();
+      client2.quit().then(() => done());
+    })
   });
 });

--- a/test/cold-brew.spec.js
+++ b/test/cold-brew.spec.js
@@ -121,7 +121,7 @@ describe('coldBrew', function () {
   describe('waitUntilRTCEvents', function () {
     let client1, client2;
 
-    before(function () {
+    beforeEach(function () {
       client1 = coldBrew.createClient();
       client2 = coldBrew.createClient();
     });
@@ -139,7 +139,21 @@ describe('coldBrew', function () {
       ]).then((occurred) => { if (occurred) done() });
     });
 
-    after(function (done) {
+    it('should detect that RTC events have occurred in a certain order', function (done) {
+      this.timeout(10000);
+
+      client1.get(ADDRESS);
+      client2.get(ADDRESS);
+
+      client1.waitUntilRTCEvents([
+        'signalingstatechange',
+        'addstream',
+      ], {
+        inOrder: true,
+      }).then((occurred) => { if (occurred) done() });
+    });
+
+    afterEach(function (done) {
       client1.quit();
       client2.quit().then(() => done());
     });


### PR DESCRIPTION
Users can now wrap their signaling socket in an "observeSignaling" function which pushes all of the socket events to the window object. They can also use the "waitUntilSendSignaling" function in the testing library to observe outgoing signaling events.
